### PR TITLE
fix: downgrade splunk version - 9.x.x throws errors during installation

### DIFF
--- a/scripts/bootstrap_vm.sh
+++ b/scripts/bootstrap_vm.sh
@@ -2,8 +2,8 @@
 #set -vxn
 
 install_splunk_uf() {
-DOWNLOAD_URL="https://download.splunk.com/products/universalforwarder/releases/9.0.3/linux/splunkforwarder-9.0.3-dd0128b1f8cd-Linux-x86_64.tgz"
-INSTALL_FILE="splunkforwarder-9.0.3-dd0128b1f8cd-Linux-x86_64.tgz"
+DOWNLOAD_URL="https://download.splunk.com/products/universalforwarder/releases/8.2.2.1/linux/splunkforwarder-8.2.2.1-ae6821b7c64b-Linux-x86_64.tgz"
+INSTALL_FILE="splunkforwarder-8.2.2.1-ae6821b7c64b-Linux-x86_64.tgz"
 INSTALL_LOCATION="/opt"
 DEPLOYMENT_SERVER_URI="splunk-lm-prod-vm00.platform.hmcts.net:8089"
 FORWARD_SERVER_URI="splunk-cm-prod-vm00.platform.hmcts.net:8089"


### PR DESCRIPTION
https://community.splunk.com/t5/Splunk-Enterprise/Invalid-Key-in-alert-actions-conf-after-upgrade-to-Splunk-9-0-0/m-p/602259 - Error in Splunk config files shipped with Splunk version greater than 9.x.x which breaks our automation.

Reverting back to the previously used version until splunk fix.

Example error: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=371463&view=logs&j=574ce25c-f2c6-5522-b40a-bcb6502180a9&t=5b02abc2-8f9b-5970-e38b-1d00631597b6


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
