### PR TITLE
fix: added depends on to workaround bug in Azure API

### DIFF
--- a/custom_script.tf
+++ b/custom_script.tf
@@ -2,6 +2,8 @@
 resource "azurerm_virtual_machine_scale_set_extension" "custom_script" {
   count = (var.install_splunk_uf == true || var.install_nessus_agent == true || var.additional_script_path != null) && var.virtual_machine_type == "vmss" ? 1 : 0
 
+  depends_on = [azurerm_virtual_machine_scale_set_extension.azure_monitor]
+
   name                         = var.custom_script_extension_name
   virtual_machine_scale_set_id = var.virtual_machine_scale_set_id
   publisher                    = lower(var.os_type) == "linux" ? "Microsoft.Azure.Extensions" : lower(var.os_type) == "windows" ? "Microsoft.Compute" : null
@@ -22,6 +24,8 @@ resource "azurerm_virtual_machine_scale_set_extension" "custom_script" {
 
 resource "azurerm_virtual_machine_extension" "custom_script" {
   count = (var.install_splunk_uf == true || var.install_nessus_agent == true || var.additional_script_path != null) && var.virtual_machine_type == "vm" ? 1 : 0
+
+  depends_on = [ azurerm_virtual_machine_extension.azure_monitor ]
 
   name                       = var.custom_script_extension_name
   virtual_machine_id         = var.virtual_machine_id

--- a/dynatrace_oneagent.tf
+++ b/dynatrace_oneagent.tf
@@ -1,6 +1,8 @@
 resource "azurerm_virtual_machine_scale_set_extension" "dynatrace_oneagent" {
   count = var.install_dynatrace_oneagent == true && var.virtual_machine_type == "vmss" ? 1 : 0
 
+  depends_on = [ azurerm_virtual_machine_scale_set_extension.custom_script ]
+
   name                         = "Dynatrace"
   virtual_machine_scale_set_id = var.virtual_machine_scale_set_id
   publisher                    = "dynatrace.ruxit"
@@ -12,6 +14,8 @@ resource "azurerm_virtual_machine_scale_set_extension" "dynatrace_oneagent" {
 
 resource "azurerm_virtual_machine_extension" "dynatrace_oneagent" {
   count = var.install_dynatrace_oneagent == true && var.virtual_machine_type == "vm" ? 1 : 0
+
+  depends_on = [ azurerm_virtual_machine_extension.custom_script ]
 
   name                       = "Dynatrace"
   virtual_machine_id         = var.virtual_machine_id

--- a/ms_endpoint_protection.tf
+++ b/ms_endpoint_protection.tf
@@ -1,6 +1,8 @@
 resource "azurerm_virtual_machine_scale_set_extension" "endpoint_protection" {
   count = var.install_endpoint_protection == true && var.os_type == "Windows" && var.virtual_machine_type == "vmss" ? 1 : 0
 
+  depends_on = [ azurerm_virtual_machine_scale_set_extension.dynatrace_oneagent ]
+
   name                         = "AntiMalwareEndpointProtection"
   virtual_machine_scale_set_id = var.virtual_machine_scale_set_id
   publisher                    = "Microsoft.Azure.Security"
@@ -18,6 +20,8 @@ resource "azurerm_virtual_machine_scale_set_extension" "endpoint_protection" {
 
 resource "azurerm_virtual_machine_extension" "endpoint_protection" {
   count = var.install_endpoint_protection == true && var.os_type == "Windows" && var.virtual_machine_type == "vm" ? 1 : 0
+
+  depends_on = [ azurerm_virtual_machine_extension.dynatrace_oneagent ]
 
   name                       = "AntiMalwareEndpointProtection"
   virtual_machine_id         = var.virtual_machine_id


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14067


### Change description ###
Added depends on to create the vm/scale set extensions sequentially. This is due to a bug in the Azure API which causes extensions to incorrectly report their install status. https://github.com/Azure/azure-rest-api-specs/issues/22434


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
