### PR TITLE
DTSPO-14061 Add app-proxy bootstrap support

### DIFF
--- a/custom_script.tf
+++ b/custom_script.tf
@@ -1,6 +1,6 @@
 # Custom Script
 resource "azurerm_virtual_machine_scale_set_extension" "custom_script" {
-  count = (var.install_splunk_uf == true || var.install_nessus_agent == true || var.additional_script_path != null) && var.virtual_machine_type == "vmss" ? 1 : 0
+  count = (var.install_splunk_uf == true || var.install_nessus_agent == true || var.install_app_proxy == true || var.additional_script_path != null) && var.virtual_machine_type == "vmss" ? 1 : 0
 
   depends_on = [azurerm_virtual_machine_scale_set_extension.azure_monitor]
 
@@ -23,9 +23,9 @@ resource "azurerm_virtual_machine_scale_set_extension" "custom_script" {
 }
 
 resource "azurerm_virtual_machine_extension" "custom_script" {
-  count = (var.install_splunk_uf == true || var.install_nessus_agent == true || var.additional_script_path != null) && var.virtual_machine_type == "vm" ? 1 : 0
+  count = (var.install_splunk_uf == true || var.install_nessus_agent == true || var.install_app_proxy == true || var.additional_script_path != null) && var.virtual_machine_type == "vm" ? 1 : 0
 
-  depends_on = [ azurerm_virtual_machine_extension.azure_monitor ]
+  depends_on = [azurerm_virtual_machine_extension.azure_monitor]
 
   name                       = var.custom_script_extension_name
   virtual_machine_id         = var.virtual_machine_id

--- a/dynatrace_oneagent.tf
+++ b/dynatrace_oneagent.tf
@@ -1,7 +1,7 @@
 resource "azurerm_virtual_machine_scale_set_extension" "dynatrace_oneagent" {
   count = var.install_dynatrace_oneagent == true && var.virtual_machine_type == "vmss" ? 1 : 0
 
-  depends_on = [ azurerm_virtual_machine_scale_set_extension.custom_script ]
+  depends_on = [azurerm_virtual_machine_scale_set_extension.custom_script]
 
   name                         = "Dynatrace"
   virtual_machine_scale_set_id = var.virtual_machine_scale_set_id
@@ -15,7 +15,7 @@ resource "azurerm_virtual_machine_scale_set_extension" "dynatrace_oneagent" {
 resource "azurerm_virtual_machine_extension" "dynatrace_oneagent" {
   count = var.install_dynatrace_oneagent == true && var.virtual_machine_type == "vm" ? 1 : 0
 
-  depends_on = [ azurerm_virtual_machine_extension.custom_script ]
+  depends_on = [azurerm_virtual_machine_extension.custom_script]
 
   name                       = "Dynatrace"
   virtual_machine_id         = var.virtual_machine_id

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,9 @@
+data "azurerm_client_config" "this" {}
+
+data "external" "this" {
+  program = ["bash", "scripts/get-access-token.sh"]
+}
+
 locals {
   # Custom Script
   bootstrap_vm_script = lower(var.os_type) == "linux" ? "scripts/bootstrap_vm.sh" : "scripts/bootstrap_vm.ps1"
@@ -6,15 +12,18 @@ locals {
   dynatrace_settings = var.dynatrace_hostgroup == null && var.dynatrace_server == null ? "{ \"tenantId\" : \"${var.dynatrace_tenant_id}\" , \"token\" : \"${var.dynatrace_token}\" , \"installerArguments\" : \"--set-network-zone=${var.dynatrace_network_zone}\" }" : var.dynatrace_hostgroup != null && var.dynatrace_server == null ? "{ \"tenantId\" : \"${var.dynatrace_tenant_id}\" , \"token\" : \"${var.dynatrace_token}\" , \"hostGroup\" : \"${var.dynatrace_hostgroup}\" , \"installerArguments\" : \"--set-network-zone=${var.dynatrace_network_zone}\"}" : var.dynatrace_hostgroup == null && var.dynatrace_server != null ? "{ \"tenantId\" : \"${var.dynatrace_tenant_id}\" , \"token\" : \"${var.dynatrace_token}\" , \"server\" : \"${var.dynatrace_server}\" , \"installerArguments\" : \"--set-network-zone=${var.dynatrace_network_zone}\" }" : "{ \"tenantId\" : \"${var.dynatrace_tenant_id}\" , \"token\" : \"${var.dynatrace_token}\" , \"hostGroup\" : \"${var.dynatrace_hostgroup}\" , \"server\" : \"${var.dynatrace_server}\" , \"installerArguments\" : \"--set-network-zone=${var.dynatrace_network_zone}\" }"
 
   template_file = base64encode(format("%s\n%s", templatefile("${path.module}/${local.bootstrap_vm_script}", {
-    UF_INSTALL      = tostring(var.install_splunk_uf),
-    UF_USERNAME     = var.splunk_username,
-    UF_PASSWORD     = var.splunk_password,
-    UF_PASS4SYMMKEY = var.splunk_pass4symmkey,
-    UF_GROUP        = var.splunk_group,
-    NESSUS_INSTALL  = var.install_nessus_agent,
-    NESSUS_SERVER   = var.nessus_server,
-    NESSUS_KEY      = var.nessus_key,
-    NESSUS_GROUPS   = var.nessus_groups
+    UF_INSTALL        = tostring(var.install_splunk_uf),
+    UF_USERNAME       = var.splunk_username,
+    UF_PASSWORD       = var.splunk_password,
+    UF_PASS4SYMMKEY   = var.splunk_pass4symmkey,
+    UF_GROUP          = var.splunk_group,
+    NESSUS_INSTALL    = var.install_nessus_agent,
+    NESSUS_SERVER     = var.nessus_server,
+    NESSUS_KEY        = var.nessus_key,
+    NESSUS_GROUPS     = var.nessus_groups,
+    APP_PROXY_INSTALL = var.install_app_proxy,
+    APP_PROXY_TOKEN   = data.external.this.result.accessToken,
+    TENANT_ID         = data.azurerm_client_config.this.tenant_id
   }), var.additional_script_path == null ? "" : file("${var.additional_script_path}")))
 
   additional_template_file = var.additional_script_uri != null ? format("%s%s%s", "[ ", "\"${var.additional_script_uri}\"", " ]") : "\"\""

--- a/ms_endpoint_protection.tf
+++ b/ms_endpoint_protection.tf
@@ -1,7 +1,7 @@
 resource "azurerm_virtual_machine_scale_set_extension" "endpoint_protection" {
   count = var.install_endpoint_protection == true && var.os_type == "Windows" && var.virtual_machine_type == "vmss" ? 1 : 0
 
-  depends_on = [ azurerm_virtual_machine_scale_set_extension.dynatrace_oneagent ]
+  depends_on = [azurerm_virtual_machine_scale_set_extension.dynatrace_oneagent]
 
   name                         = "AntiMalwareEndpointProtection"
   virtual_machine_scale_set_id = var.virtual_machine_scale_set_id
@@ -21,7 +21,7 @@ resource "azurerm_virtual_machine_scale_set_extension" "endpoint_protection" {
 resource "azurerm_virtual_machine_extension" "endpoint_protection" {
   count = var.install_endpoint_protection == true && var.os_type == "Windows" && var.virtual_machine_type == "vm" ? 1 : 0
 
-  depends_on = [ azurerm_virtual_machine_extension.dynatrace_oneagent ]
+  depends_on = [azurerm_virtual_machine_extension.dynatrace_oneagent]
 
   name                       = "AntiMalwareEndpointProtection"
   virtual_machine_id         = var.virtual_machine_id

--- a/scripts/get-access-token.sh
+++ b/scripts/get-access-token.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+az account get-access-token --resource-type 'aad-graph' --scope 'https://proxy.cloudwebappproxy.net/registerapp/user_impersonation'

--- a/variables.tf
+++ b/variables.tf
@@ -205,6 +205,7 @@ variable "install_endpoint_protection" {
   default     = true
 }
 
+
 variable "endpoint_protection_handler_version" {
   description = "Enable Antimalware Protection."
   type        = string
@@ -280,4 +281,10 @@ variable "run_command_type_handler_version_windows" {
 
 variable "rc_os_sku" {
   default = null
+}
+
+variable "install_app_proxy" {
+  description = "Install Azure App Proxy."
+  default     = false
+  type        = bool
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-14061



This change:
  - Adds support for app-proxy bootstrapping via the module instead of adding the machine extensions in the app-proxy repository. Migrates existing scripts and powershell functionality to this repo.
  - Updates some files that terraform fmt spotted]
  

Originally tried to convert `scripts/get-access-token.sh` into powershell to include all functionality natively but there is no option for `-scope` within that cmdlet

Code ported over from https://github.com/hmcts/azure-app-proxy - with pending changes to use this module change that will be pushed soon.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
