### PR TITLE
Fix typo in bootstrap_vm.sh

### DIFF
--- a/scripts/bootstrap_vm.sh
+++ b/scripts/bootstrap_vm.sh
@@ -111,7 +111,7 @@ get_download_id () {
 check_download_url () {
  # use curl to get the HTTP status code
   url="https://www.tenable.com/downloads/api/v1/public/pages/nessus-agents/downloads/$1/download?i_agree_to_tenable_license_agreement=true"
-  urlstatus=$(curl -o /dev/null --silent --head --write-out '%%{http_code}' "$url")
+  urlstatus=$(curl -o /dev/null --silent --head --write-out '%{http_code}' "$url")
   # if the status code is 404, print a message and exit with 1
   if [ "$urlstatus" == "404" ]; then
     echo "The URL $url gives 404 error"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-14077

### Change description ###

Fix a typo in bootstrap_vm.sh that prevents curl from getting the HTTP response code of a URL

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
