### PR TITLE
feat: add remove splunk logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A virtual machine or virtual machine scale set.
 | <a name="input_rc_os_sku"></a> [rc\_os\_sku](#input\_rc\_os\_sku) | n/a | `any` | `null` | no |
 | <a name="input_rc_script_file"></a> [rc\_script\_file](#input\_rc\_script\_file) | A path to a local file for the script | `any` | `null` | no |
 | <a name="input_realtimeprotectionenabled"></a> [realtimeprotectionenabled](#input\_realtimeprotectionenabled) | Enable Realtime Protection | `string` | `true` | no |
+| <a name="input_remove_splunk_uf"></a> [remove\_splunk\_uf](#input\_remove\_splunk\_uf) | Remove Splunk UF if it is installed. Overrides install\_splunk\_uf if set to true. | `bool` | `true` | no |
 | <a name="input_run_cis"></a> [run\_cis](#input\_run\_cis) | Install CIS hardening using run command script? | `bool` | `false` | no |
 | <a name="input_run_command"></a> [run\_command](#input\_run\_command) | n/a | `bool` | `false` | no |
 | <a name="input_run_command_sa_key"></a> [run\_command\_sa\_key](#input\_run\_command\_sa\_key) | SA key for the run command | `string` | `""` | no |

--- a/custom_script.tf
+++ b/custom_script.tf
@@ -1,7 +1,6 @@
 # Custom Script
 resource "azurerm_virtual_machine_scale_set_extension" "custom_script" {
-  count = (var.install_splunk_uf == true || var.install_nessus_agent == true || var.additional_script_path != null) && var.virtual_machine_type == "vmss" ? 1 : 0
-
+  count = (var.remove_splunk_uf == true || var.install_nessus_agent == true || var.additional_script_path != null) && var.virtual_machine_type == "vmss" ? 1 : 0
 
   name                         = var.custom_script_extension_name
   virtual_machine_scale_set_id = var.virtual_machine_scale_set_id
@@ -22,7 +21,7 @@ resource "azurerm_virtual_machine_scale_set_extension" "custom_script" {
 }
 
 resource "azurerm_virtual_machine_extension" "custom_script" {
-  count = (var.install_splunk_uf == true || var.install_nessus_agent == true || var.additional_script_path != null) && var.virtual_machine_type == "vm" ? 1 : 0
+  count = (var.remove_splunk_uf == true || var.install_nessus_agent == true || var.additional_script_path != null) && var.virtual_machine_type == "vm" ? 1 : 0
 
   name                       = var.custom_script_extension_name
   virtual_machine_id         = var.virtual_machine_id

--- a/locals.tf
+++ b/locals.tf
@@ -18,7 +18,8 @@ locals {
 
   template_file = base64encode(format("%s\n%s", templatefile("${path.module}/${local.bootstrap_vm_script}",
     {
-      UF_INSTALL      = tostring(var.install_splunk_uf),
+      UF_INSTALL      = tostring(var.install_splunk_uf)
+      UF_REMOVE       = tostring(var.remove_splunk_uf)
       UF_USERNAME     = var.splunk_username == null || var.splunk_username == "" ? (length(data.azurerm_key_vault_secret.splunk_username) > 0 ? data.azurerm_key_vault_secret.splunk_username[0].value : "") : var.splunk_username
       UF_PASSWORD     = var.splunk_password == null || var.splunk_password == "" ? (length(data.azurerm_key_vault_secret.splunk_password) > 0 ? data.azurerm_key_vault_secret.splunk_password[0].value : "") : var.splunk_password
       UF_PASS4SYMMKEY = var.splunk_pass4symmkey == null || var.splunk_pass4symmkey == "" ? (length(data.azurerm_key_vault_secret.splunk_pass4symmkey) > 0 ? data.azurerm_key_vault_secret.splunk_pass4symmkey[0].value : "") : var.splunk_pass4symmkey

--- a/tests/linux_vm_extensions.tftest.hcl
+++ b/tests/linux_vm_extensions.tftest.hcl
@@ -150,7 +150,7 @@ run "virtual_machine_no_azure_monitor_extension" {
   }
 }
 
-# Custom scipt should still install when nessus is disabled but splunk is still enabled
+// Custom scipt should still install when nessus is disabled but splunk removal is still enabled (default)
 run "virtual_machine_no_nessus" {
 
   command = plan
@@ -159,6 +159,7 @@ run "virtual_machine_no_nessus" {
     virtual_machine_type = "vm"
     virtual_machine_id   = run.setup_vm.vm_id
     install_nessus_agent = false
+    # remove_splunk_uf defaults to true
   }
 
   assert {
@@ -175,7 +176,7 @@ run "virtual_machine_no_splunk" {
   variables {
     virtual_machine_type = "vm"
     virtual_machine_id   = run.setup_vm.vm_id
-    install_splunk_uf    = false
+    remove_splunk_uf     = false
   }
 
   assert {
@@ -184,7 +185,7 @@ run "virtual_machine_no_splunk" {
   }
 }
 
-# Custom scipt should not be installed when both nessus and splunk are disabled
+# Custom scipt should not be installed when both nessus and splunk removal are disabled
 # TODO: add a test for additional script as that is installed here as well
 run "virtual_machine_no_nessus_or_splunk" {
 
@@ -193,7 +194,7 @@ run "virtual_machine_no_nessus_or_splunk" {
   variables {
     virtual_machine_type = "vm"
     virtual_machine_id   = run.setup_vm.vm_id
-    install_splunk_uf    = false
+    remove_splunk_uf     = false
     install_nessus_agent = false
   }
 

--- a/tests/linux_vmss_extensions.tftest.hcl
+++ b/tests/linux_vmss_extensions.tftest.hcl
@@ -175,12 +175,12 @@ run "virtual_machine_scale_set_no_splunk" {
   variables {
     virtual_machine_type         = "vmss"
     virtual_machine_scale_set_id = run.setup_vm.vmss_id
-    install_splunk_uf            = false
+    remove_splunk_uf             = false
   }
 
   assert {
     condition     = length(azurerm_virtual_machine_scale_set_extension.custom_script) == 1
-    error_message = "Custom script not installed when only nessus is disabled"
+    error_message = "Custom script installed when nessus and splunk install/remove are disabled"
   }
 }
 
@@ -193,7 +193,7 @@ run "virtual_machine_scale_set_no_nessus_or_splunk" {
   variables {
     virtual_machine_type         = "vmss"
     virtual_machine_scale_set_id = run.setup_vm.vmss_id
-    install_splunk_uf            = false
+    remove_splunk_uf             = false
     install_nessus_agent         = false
   }
 

--- a/tests/windows_vm_extensions.tftest.hcl
+++ b/tests/windows_vm_extensions.tftest.hcl
@@ -175,7 +175,7 @@ run "virtual_machine_no_splunk" {
   variables {
     virtual_machine_type = "vm"
     virtual_machine_id   = run.setup_vm.vm_id
-    install_splunk_uf    = false
+    remove_splunk_uf     = false
   }
 
   assert {
@@ -211,7 +211,7 @@ run "virtual_machine_no_nessus_or_splunk" {
   variables {
     virtual_machine_type = "vm"
     virtual_machine_id   = run.setup_vm.vm_id
-    install_splunk_uf    = false
+    remove_splunk_uf     = false
     install_nessus_agent = false
   }
 

--- a/tests/windows_vmss_extensions.tftest.hcl
+++ b/tests/windows_vmss_extensions.tftest.hcl
@@ -175,7 +175,7 @@ run "virtual_machine_scale_set_no_splunk" {
   variables {
     virtual_machine_type         = "vmss"
     virtual_machine_scale_set_id = run.setup_vm.vmss_id
-    install_splunk_uf            = false
+    remove_splunk_uf             = false
   }
 
   assert {
@@ -211,7 +211,7 @@ run "virtual_machine_scale_set_no_nessus_or_splunk" {
   variables {
     virtual_machine_type         = "vmss"
     virtual_machine_scale_set_id = run.setup_vm.vmss_id
-    install_splunk_uf            = false
+    remove_splunk_uf             = false
     install_nessus_agent         = false
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,3 @@
-
 # VM/VMSS Extension General
 variable "common_tags" {
   description = "Common Tags"
@@ -195,6 +194,12 @@ variable "nessus_groups" {
 # Splunk UF
 variable "install_splunk_uf" {
   description = "Install Splunk UF."
+  default     = true
+  type        = bool
+}
+
+variable "remove_splunk_uf" {
+  description = "Remove Splunk UF if it is installed. Overrides install_splunk_uf if set to true."
   default     = true
   type        = bool
 }


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPO-24115](https://tools.hmcts.net/jira/browse/DTSPO-24115)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->
This PR introduces the capability to remove the Splunk Universal Forwarder (UF) as part of the VM bootstrap process, facilitating its decommissioning.

Key changes include:
*   Added a new Terraform variable `remove_splunk_uf` (defaulting to `true`) to control the removal action.
*   Updated `locals.tf` to pass this new variable to the bootstrap scripts.
*   Modified the Linux bootstrap script (`bootstrap_vm.sh`):
    *   Added logic to check for and remove Splunk UF if `remove_splunk_uf` is true. This includes stopping the service, disabling boot-start, and removing files. The script checks if Splunk exists before attempting removal to avoid errors.
    *   Removed logic to install Splunk, whilst keeping the `install_splunk_uf` variable so as not to break anything reliant on it.
*   Updated `custom_script.tf`: Modified the `count` logic for the Custom Script Extension resources to ensure the bootstrap script runs if `remove_splunk_uf` is true, even if `install_splunk_uf` is false.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
Tested on Bastion pipeline - https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=809398&view=logs&j=24dc66af-dff3-54f8-0cc0-b4c2918249f7&t=ea3c748b-52dd-54ea-c17f-efbc76e25b0a 

As you can see Splunk is not installed anymore:

```
daniel.alves@justice.gov.uk@bastion-sbox:~$ ls -la /opt/
total 20
drwxr-xr-x  6 root root 4096 May  1 13:56 .
drwxr-xr-x 22 root root 4096 May  1 06:42 ..
drwxr-xr-x  6 root root 4096 Feb 26 09:54 az
drwxr-xr-x  2 root root    6 Sep  7  2023 data-migration
drwxr-xr-x  3 root root 4096 Feb 26 14:11 dynatrace
drwxr-xr-x  3 root root 4096 Feb 26 14:11 microsoft
daniel.alves@justice.gov.uk@bastion-sbox:~$ systemctl status SplunkForwarder.service
Unit SplunkForwarder.service could not be found.
```

VMSS testing pending...

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change