### PR TITLE
Make os type check on protected settings case insensitive

### DIFF
--- a/custom_script.tf
+++ b/custom_script.tf
@@ -31,7 +31,7 @@ resource "azurerm_virtual_machine_extension" "custom_script" {
   auto_upgrade_minor_version = false
   protected_settings         = <<PROTECTED_SETTINGS
     {
-      %{if var.os_type == "Linux"}
+      %{if lower(var.os_type) == "linux"}
       "script": "${local.template_file}"
       %{else}
       "fileUris": ${local.additional_template_file},


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25281

### Change description
Ensure that the os_type conditional for protected settings on vm extension is case insensitive

### Testing done
I can see that a wrong branch is getting executed because os_type is lower case linux here: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=811824&view=logs&j=972fdc6b-e075-5228-ef85-c1306ebc07f0&t=b392e54b-70b0-54a2-7abc-60561a4a08fe

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
